### PR TITLE
chore/fix(playlists): format omitted playlist

### DIFF
--- a/blueprint/blueprint.go
+++ b/blueprint/blueprint.go
@@ -99,10 +99,10 @@ type PlaylistSearchResult struct {
 // PlatformSearchTrack represents the key-value parameter passed
 // when trying to convert playlist from spotify
 type PlatformSearchTrack struct {
-	Artiste string `json:"artiste"`
-	Title   string `json:"title"`
-	ID      string `json:"id"`
-	URL     string `json:"url"`
+	Artistes []string `json:"artiste"`
+	Title    string   `json:"title"`
+	ID       string   `json:"id"`
+	URL      string   `json:"url"`
 }
 
 // Conversion represents the final response for a typical track conversion
@@ -124,12 +124,12 @@ type PlaylistConversion struct {
 		Spotify *[]TrackSearchResult `json:"spotify"`
 		Tidal   *[]TrackSearchResult `json:"tidal"`
 	} `json:"tracks"`
-	Length        string          `json:"length"`
-	Title         string          `json:"title"`
-	Preview       string          `json:"preview,omitempty"` // if no preview, not important to be bothered for now, API doesn't have to show it
-	OmittedTracks []OmittedTracks `json:"omitted_tracks"`
-	Owner         string          `json:"owner"`
-	Cover         string          `json:"cover"`
+	Length        string                     `json:"length"`
+	Title         string                     `json:"title"`
+	Preview       string                     `json:"preview,omitempty"` // if no preview, not important to be bothered for now, API doesn't have to show it
+	OmittedTracks map[string][]OmittedTracks `json:"omitted_tracks"`
+	Owner         string                     `json:"owner"`
+	Cover         string                     `json:"cover"`
 }
 
 //type PlaylistPayload struct {
@@ -153,9 +153,9 @@ type Message struct {
 
 // OmittedTracks represents tracks that could not be processed in a playlist, for whatever reason
 type OmittedTracks struct {
-	Title   string `json:"title"`
-	URL     string `json:"url"`
-	Artiste string `json:"artiste"`
+	Title    string   `json:"title"`
+	URL      string   `json:"url"`
+	Artistes []string `json:"artistes"`
 }
 
 // WebsocketErrorMessage represents the error message sent from the server to the client over websocket

--- a/services/spotify/base.go
+++ b/services/spotify/base.go
@@ -400,7 +400,8 @@ func FetchTracks(tracks []blueprint.PlatformSearchTrack, red *redis.Client) (*[]
 	var omittedTracks []blueprint.OmittedTracks
 	var wg sync.WaitGroup
 	for _, t := range tracks {
-		go SearchTrackWithTitleChan(t.Title, t.Artiste, ch, &wg, red)
+		// WARNING: unhandled slice index
+		go SearchTrackWithTitleChan(t.Title, t.Artistes[0], ch, &wg, red)
 		outputTrack := <-ch
 		// for some reason, there is no spotify url which means could not fetch track, we
 		// want to add to the list of "not found" tracks.
@@ -408,9 +409,10 @@ func FetchTracks(tracks []blueprint.PlatformSearchTrack, red *redis.Client) (*[]
 			// log info about empty track
 			log.Printf("\n[services][spotify][base][FetchPlaylistSearchResult][warn] - Could not find track for %s\n", t.Title)
 			omittedTracks = append(omittedTracks, blueprint.OmittedTracks{
-				Title:   t.Title,
-				URL:     t.URL,
-				Artiste: t.Artiste,
+				Title: t.Title,
+				URL:   t.URL,
+				// WARNING: unhandled slice index
+				Artistes: t.Artistes,
 			})
 			continue
 		}
@@ -428,10 +430,10 @@ func FetchPlaylistSearchResult(p *blueprint.PlaylistSearchResult, red *redis.Cli
 	var trackSearch []blueprint.PlatformSearchTrack
 	for _, track := range p.Tracks {
 		trackSearch = append(trackSearch, blueprint.PlatformSearchTrack{
-			Artiste: track.Artistes[0],
-			Title:   track.Title,
-			ID:      track.ID,
-			URL:     track.URL,
+			Artistes: track.Artistes,
+			Title:    track.Title,
+			ID:       track.ID,
+			URL:      track.URL,
 		})
 	}
 	track, omittedTracks := FetchTracks(trackSearch, red)

--- a/util/util.go
+++ b/util/util.go
@@ -128,13 +128,21 @@ func DeezerIsExplicit(v int) bool {
 	return out
 }
 
-// GetFormattedDuration returns the duration of a track in format ``hh:mm``
+// GetFormattedDuration returns the duration of a track in format ``dd:hh:mm`` if it reaches days
+// or ``hh:mm:ss`` if it's less than a day
 func GetFormattedDuration(v int) string {
+	day := 0
 	hour := v / 60
 	sec := v % 60
 	seconds := strconv.Itoa(sec)
 	if len(seconds) == 1 {
 		seconds = "0" + seconds
+	}
+
+	if hour >= 24 {
+		day = hour / 60
+		hour = hour % 60
+		return fmt.Sprintf("%d:%d:%s", day, hour, seconds)
 	}
 	return fmt.Sprintf("%d:%s", hour, seconds)
 }


### PR DESCRIPTION
 - cleanup omitted playlist response to return a key-value response of platform and array of object containing 'title', 'url' and 'id' of omitted tracks.
 - Also fixed empty values in this object for spotify